### PR TITLE
feat: Add IAM permissions for bootstrap and fix dependency cycle (#3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## First Steps
+
+**Your first tool call in this repository MUST be reading .claude/CODING_STANDARD.md.
+Do not read any other files, search, or take any actions until you have read it.**
+This contains InfraHouse's comprehensive coding standards for Terraform, Python, and general formatting rules.
+
+## Build and Test Commands
+
+```bash
+make bootstrap                              # Install Python deps (pip, setuptools, requirements.txt)
+make format                                 # Format Terraform (terraform fmt -recursive) and Python (black tests)
+make lint                                   # Check formatting without modifying files
+make docs                                   # Regenerate terraform-docs in README.md
+make test                                   # Full test suite (all AWS provider versions)
+make test-keep                              # Run tests, keep infrastructure for debugging
+make test-keep TEST_SELECTOR=aws-6          # Test only AWS provider v6
+make test-keep TEST_SELECTOR=aws-5          # Test only AWS provider v5
+make test-clean                             # Run tests and destroy resources (run before PRs)
+make release-patch                          # Bump patch version, update CHANGELOG, create tag
+```
+
+Tests are parameterized pytest integration tests that deploy real AWS infrastructure. They run against both AWS provider v5 (`~> 5.62`) and v6 (`~> 6.0`). Test root module lives in `test_data/percona-server/`.
+
+Default test config: `TEST_REGION=us-west-1`, `TEST_ROLE=arn:aws:iam::303467602807:role/percona-server-tester`.
+
+## Architecture
+
+This module deploys a highly available Percona Server (MySQL 8.0) cluster on AWS with GTID-based replication. Key components:
+
+- **ASG** (`main.tf`): Launch template with IMDSv2 enforcement + Auto Scaling Group with rolling updates
+- **NLB** (`nlb.tf`): Internal Network Load Balancer with write (port 3306, master) and read (port 3307, replicas) target groups
+- **DynamoDB** (`dynamodb.tf`): Distributed locks and topology management with TTL
+- **S3** (`s3.tf`): XtraBackup snapshots and binary log storage with lifecycle policies
+- **Secrets** (`secrets.tf`): MySQL credentials (root, replication, backup, monitor) and LUKS passphrase via `infrahouse/secret/aws`
+- **IAM** (`iam.tf`): Instance profile with least-privilege permissions for DynamoDB, S3, ASG, ELB, EC2
+- **Cloud-init** (`cloud_init.tf`): Bootstrap via Puppet with custom facts passed through instance tags (prefixed `percona:`)
+- **Security Groups** (`security_group.tf`): MySQL, Orchestrator HTTP/Raft, and ICMP rules
+
+Storage type (EBS vs NVMe instance store) is auto-detected from the instance type in `locals.tf`.
+
+### Module Dependencies
+
+All InfraHouse modules use `registry.infrahouse.com` with exact version pinning:
+
+- `infrahouse/instance-profile/aws` - IAM instance profile
+- `infrahouse/cloud-init/aws` - Cloud-init + Puppet integration
+- `infrahouse/s3-bucket/aws` - S3 with encryption/lifecycle
+- `infrahouse/secret/aws` - Secrets Manager credentials
+
+### Data Flow
+
+- **Write path**: App -> NLB:3306 -> Write TG -> Master instance
+- **Read path**: App -> NLB:3307 -> Read TG -> Replica instances
+- **Replication**: Master -> Binary Log -> GTID Replication -> Replicas
+- **Backup**: Master -> XtraBackup -> S3 (full + incremental, retention controlled by `backup_retention_weeks`)
+
+## Key Conventions
+
+- Module version tracked in `locals.tf` (`local.module_version`) and `.bumpversion.cfg`
+- Instance count must be odd (3, 5, 7+) for quorum - enforced by variable validation
+- Puppet facts are passed via EC2 instance tags (see `local.instance_tags` in `locals.tf`)
+- `cancel_instance_refresh_on_error = true` in cloud-init prevents cascading ASG failures
+- Checkov skip justifications are documented in `.checkov.yml`
+- Max line length: 120 characters for all files
+- All files must end with a newline

--- a/iam.tf
+++ b/iam.tf
@@ -9,7 +9,7 @@ module "instance_profile" {
 }
 
 # Combined permissions policy document
-# checkov:skip=CKV_AWS_356:DescribeAutoScalingInstances, DescribeInstances, and DescribeTags do not support resource-level permissions
+# checkov:skip=CKV_AWS_356:DescribeAutoScalingInstances, DescribeInstances, DescribeTags, and GetCommandInvocation do not support resource-level permissions
 data "aws_iam_policy_document" "percona" {
   # DynamoDB access (locks and topology)
   statement {
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "percona" {
       "autoscaling:SetInstanceHealth",
       "autoscaling:CancelInstanceRefresh",
     ]
-    resources = [aws_autoscaling_group.percona.arn]
+    resources = [local.asg_arn_pattern]
   }
 
   # Auto Scaling describe (not restrictable to specific resources)
@@ -88,6 +88,61 @@ data "aws_iam_policy_document" "percona" {
     actions = [
       "ec2:DescribeInstances",
       "ec2:DescribeTags",
+    ]
+    resources = ["*"]
+  }
+
+  # EC2 tagging (instances tag themselves for role discovery)
+  statement {
+    sid    = "EC2CreateTags"
+    effect = "Allow"
+    actions = [
+      "ec2:CreateTags",
+    ]
+    resources = [
+      "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:instance/*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/cluster_id"
+      values   = [var.cluster_id]
+    }
+  }
+
+  # SSM (send commands to cluster instances for coordination)
+  statement {
+    sid    = "SSMSendCommand"
+    effect = "Allow"
+    actions = [
+      "ssm:SendCommand",
+    ]
+    resources = [
+      "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:instance/*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/cluster_id"
+      values   = [var.cluster_id]
+    }
+  }
+
+  statement {
+    sid    = "SSMSendCommandDocument"
+    effect = "Allow"
+    actions = [
+      "ssm:SendCommand",
+    ]
+    resources = [
+      "arn:aws:ssm:${data.aws_region.current.name}::document/AWS-RunShellScript",
+    ]
+  }
+
+  # SSM GetCommandInvocation does not support resource-level permissions
+  statement {
+    sid    = "SSMGetCommandInvocation"
+    effect = "Allow"
+    actions = [
+      "ssm:GetCommandInvocation",
     ]
     resources = ["*"]
   }

--- a/locals.tf
+++ b/locals.tf
@@ -3,6 +3,18 @@ locals {
 
   name_prefix = "percona-${var.cluster_id}"
 
+  # Constructed ARN pattern for the ASG to avoid a dependency cycle:
+  # The IAM policy doc cannot reference aws_autoscaling_group.percona.arn
+  # because instance_profile depends on the policy, and ASG depends on instance_profile.
+  asg_arn_pattern = join(":", [
+    "arn",
+    "aws",
+    "autoscaling",
+    data.aws_region.current.name,
+    data.aws_caller_identity.current.account_id,
+    "autoScalingGroup:*:autoScalingGroupName/${local.name_prefix}-*",
+  ])
+
   lts_codenames = ["noble"]
 
   ami_name_pattern = contains(local.lts_codenames, var.ubuntu_codename) ? (

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -40,7 +40,6 @@ def test_module(
     - S3 bucket is created
     """
     subnet_private_ids = service_network["subnet_private_ids"]["value"]
-    internet_gateway_id = service_network["internet_gateway_id"]["value"]
 
     terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "percona-server")
 


### PR DESCRIPTION
- Break Terraform dependency cycle by constructing ASG ARN pattern
  in locals instead of referencing aws_autoscaling_group.percona.arn
- Add ec2:CreateTags permission for instance self-tagging (role discovery)
- Add ssm:SendCommand and ssm:GetCommandInvocation for cluster
  coordination during master election and replica bootstrap
- Remove unused internet_gateway_id variable from test
