### PR TITLE
feat: Add end-to-end Sakila integration test (#3)

### DIFF
--- a/.claude/plans/poc-sakila-test.md
+++ b/.claude/plans/poc-sakila-test.md
@@ -1,0 +1,129 @@
+# PoC: Sakila Database Integration Test
+
+## Goal
+
+Verify end-to-end MySQL cluster functionality by connecting from a jumphost
+(emulating an application), creating the Sakila database, and querying it
+through both write and read NLB endpoints.
+
+## Current State
+
+| Item | Status |
+|------|--------|
+| Percona cluster running with GTID replication | Done |
+| NLB write (3306) / read (3307) endpoints | Done |
+| Security group allows VPC CIDR on 3306 | Done |
+| IAM: SSM, DynamoDB, S3, EC2 tags, ELB | Done |
+
+## What Needs to Be Done
+
+### 1. Add jumphost fixture to the test
+
+Add `jumphost` as a parameter to the test function. It will pull in `subzone`
+and other dependencies automatically. Need to pass `--test-zone-name` to pytest
+(in Makefile or CLI).
+
+### 3. Create an application MySQL user secret in test_data
+
+In `test_data/percona-server/`:
+- Generate username/password with `random_password`
+- Store in `infrahouse/secret/aws` secret
+- Grant the jumphost instance role permission to read it via `readers`
+- Output the secret name/ARN for use in the test
+
+### 4. Wait for Puppet to finish on all 3 instances
+
+The cloud-init module (v2.2.3) already creates `/var/run/puppet-done`
+after `ih-puppet apply` completes. No changes needed to the module.
+
+In the test, poll all 3 instances with
+`execute_command("ls /var/run/puppet-done")` in a loop (with timeout)
+until all return exit code 0.
+
+### 5. Create the app user on the master via SSM
+
+Use `infrahouse-core`'s `EC2Instance` / `ASGInstance` which implement
+`execute_command()`. From the test:
+- Find the master instance (query DynamoDB topology or describe ASG + tags)
+- `execute_command()` to run:
+  ```sql
+  CREATE USER 'sakila_user'@'10.1.%' IDENTIFIED BY '<password>';
+  GRANT ALL ON sakila.* TO 'sakila_user'@'10.1.%';
+  FLUSH PRIVILEGES;
+  ```
+
+### 5. Install PyMySQL on the jumphost
+
+Use `execute_command()` on the jumphost instance:
+`apt-get install -y python3-pymysql`
+
+### 6. Load Sakila schema on the master via SSM
+
+Use `execute_command()` on the master instance to:
+1. Download Sakila: `wget https://downloads.mysql.com/docs/sakila-db.tar.gz`
+2. Extract and load: `mysql < sakila-schema.sql && mysql < sakila-data.sql`
+
+### 7. Query Sakila from the jumphost
+
+Use `execute_command()` on the jumphost to run a Python script that:
+1. Reads the app user password from Secrets Manager
+2. Connects to NLB write endpoint (dns:3306)
+3. `SELECT * FROM sakila.actor` — verify data exists
+4. Connects to NLB read endpoint (dns:3307)
+5. `SELECT * FROM sakila.actor` — verify replication works
+
+## Proposed Test Flow
+
+```python
+def test_module():
+    # Step 1: Percona cluster (existing)
+    with terraform_apply(percona-server) as tf_output:
+        # Step 2: Jumphost
+        with terraform_apply(jumphost) as jh_output:
+            # Step 3: App user secret already created by Terraform
+
+            # Step 4: Create app user on master via SSM
+            send_command_to_master(
+                "mysql -e \"CREATE USER ... GRANT ALL ...\""
+            )
+
+            # Step 5-6: Run test script on jumphost
+            #   - pip install pymysql
+            #   - read secret from Secrets Manager
+            #   - connect to NLB:3306, create sakila, load data
+            #   - connect to NLB:3307, SELECT from actor
+            #   - assert results match
+```
+
+## Architecture
+
+```
+                    VPC 10.1.0.0/16
+ ┌──────────────────────────────────────────┐
+ │  Public Subnets         Private Subnets  │
+ │  ┌──────────┐          ┌──────────────┐  │
+ │  │ Jumphost │          │ Percona (x3) │  │
+ │  │ NLB      │          │ Master + 2R  │  │
+ │  └────┬─────┘          └──────┬───────┘  │
+ │       │                       │          │
+ │       │    NLB (internal)     │          │
+ │       │   :3306 write ────────┤          │
+ │       │   :3307 read  ────────┘          │
+ │       │                                  │
+ │       └───── pymysql ──── NLB ───────────│
+ └──────────────────────────────────────────┘
+```
+
+## No Changes Needed
+
+- Networking: jumphost and Percona in same VPC
+- Security group: already allows VPC CIDR on 3306
+- NLB: already has write/read listeners
+- IAM for Percona instances: SSM, DynamoDB, etc. already in place
+
+## Open Questions
+
+- ~~Where to create the app user~~ — ad-hoc from the test via SSM
+- ~~Sakila: download tarball or embed SQL~~ — download on master via SSM
+- ~~SSM helper~~ — use infrahouse-core's ASG class (we know the ASG name
+  from tf_output), get instances via its property, call `execute_command()`

--- a/test_data/percona-server/main.tf
+++ b/test_data/percona-server/main.tf
@@ -4,7 +4,8 @@ locals {
   # DescribeTable is called with empty TableName when name depends on
   # an unknown value like random_pet.id.
   # See: https://github.com/hashicorp/terraform-provider-aws/issues/46016
-  cluster_id = "test-percona"
+  cluster_id    = "test-percona"
+  app_user_name = "app_${random_pet.app_user.id}"
 }
 
 resource "aws_key_pair" "test" {
@@ -23,3 +24,11 @@ module "percona-server" {
   s3_force_destroy = true
   key_name         = aws_key_pair.test.key_name
 }
+
+# Application user for integration testing
+resource "random_password" "app_user" {
+  length  = 32
+  special = false
+}
+
+resource "random_pet" "app_user" {}

--- a/test_data/percona-server/outputs.tf
+++ b/test_data/percona-server/outputs.tf
@@ -27,3 +27,19 @@ output "s3_bucket_name" {
   description = "Name of the S3 bucket for backups"
   value       = module.percona-server.s3_bucket_name
 }
+
+output "mysql_credentials_secret_name" {
+  description = "Name of the MySQL credentials secret"
+  value       = module.percona-server.mysql_credentials_secret_name
+}
+
+output "app_user_name" {
+  description = "Application MySQL username for testing"
+  value       = local.app_user_name
+}
+
+output "app_user_password" {
+  description = "Application MySQL password for testing"
+  value       = random_password.app_user.result
+  sensitive   = true
+}

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,22 +1,94 @@
 """
 Tests for terraform-aws-percona-server module.
 
-These tests verify the Infrastructure components (Epic #2):
-- ASG configuration
-- NLB with write/read target groups
-- DynamoDB table for locks and topology
-- S3 bucket for backups and binlogs
+These tests verify:
+- Infrastructure components (ASG, NLB, DynamoDB, S3)
+- Percona Server bootstrap with GTID replication (Epic #3)
+- End-to-end MySQL connectivity through NLB write/read endpoints
 """
 
 import json
+import time
 from os import path as osp, remove
 from shutil import rmtree
 from textwrap import dedent
 
 import pytest
+from infrahouse_core.aws.asg import ASG
+from infrahouse_core.aws.asg_instance import ASGInstance
+from infrahouse_core.timeout import timeout
 from pytest_infrahouse import terraform_apply
 
 from tests.conftest import LOG, TERRAFORM_ROOT_DIR
+
+PUPPET_DONE_TIMEOUT = 900  # 15 minutes for Puppet to finish
+PUPPET_POLL_INTERVAL = 30
+REPLICATION_WAIT = 10  # seconds to wait for replication to catch up
+
+
+def wait_for_puppet(asg: ASG, wait_timeout: int = PUPPET_DONE_TIMEOUT):
+    """Wait for Puppet to finish on all instances in the ASG.
+
+    Polls each instance for /var/run/puppet-done marker file.
+
+    :param asg: ASG object with instances to wait on.
+    :param wait_timeout: Maximum seconds to wait.
+    :raises TimeoutError: if puppet doesn't finish in time.
+    """
+    instances = asg.instances
+    pending = {inst.instance_id for inst in instances}
+    LOG.info(
+        "Waiting for Puppet to finish on %d instances: %s",
+        len(pending),
+        pending,
+    )
+
+    with timeout(wait_timeout):
+        while pending:
+            for instance in instances:
+                if instance.instance_id not in pending:
+                    continue
+                try:
+                    exit_code, _, _ = instance.execute_command(
+                        "ls /var/run/puppet-done"
+                    )
+                    if exit_code == 0:
+                        LOG.info("Puppet finished on %s", instance.instance_id)
+                        pending.discard(instance.instance_id)
+                except Exception as exc:
+                    LOG.debug(
+                        "Instance %s not ready yet: %s",
+                        instance.instance_id,
+                        exc,
+                    )
+            if pending:
+                LOG.info(
+                    "Still waiting for Puppet on %d instances: %s",
+                    len(pending),
+                    pending,
+                )
+                time.sleep(PUPPET_POLL_INTERVAL)
+
+    LOG.info("Puppet finished on all instances")
+
+
+def find_master(asg: ASG) -> ASGInstance:
+    """Find the master instance by checking mysql_role tag.
+
+    :param asg: ASG object.
+    :return: Instance ID of the master.
+    :raises RuntimeError: if no master found.
+    """
+    for instance in asg.instances:
+        tags = instance.tags
+        if tags.get("mysql_role") == "master":
+            LOG.info(
+                "Found master: %s (%s)",
+                instance.instance_id,
+                instance.private_ip,
+            )
+            return instance
+    raise RuntimeError("No master instance found in ASG")
 
 
 @pytest.mark.parametrize(
@@ -24,20 +96,21 @@ from tests.conftest import LOG, TERRAFORM_ROOT_DIR
 )
 def test_module(
     service_network,
+    jumphost,
     test_role_arn,
     keep_after,
     aws_region,
     aws_provider_version,
 ):
     """
-    Test the Percona Server module infrastructure components.
+    Test the Percona Server module end-to-end.
 
     This test verifies:
     - Module can be planned and applied successfully
-    - ASG is created with correct configuration
-    - NLB and target groups are created
-    - DynamoDB table is created
-    - S3 bucket is created
+    - ASG, NLB, DynamoDB table, and S3 bucket are created
+    - Puppet finishes on all instances
+    - Master election and GTID replication work
+    - Application can connect via NLB write and read endpoints
     """
     subnet_private_ids = service_network["subnet_private_ids"]["value"]
 
@@ -105,32 +178,133 @@ def test_module(
     ) as tf_output:
         LOG.info("Terraform output: %s", json.dumps(tf_output, indent=4))
 
-        # Verify ASG was created
-        assert "asg_name" in tf_output, "ASG name should be in outputs"
+        # Verify infrastructure outputs
         assert tf_output["asg_name"]["value"], "ASG name should not be empty"
+        assert tf_output["nlb_dns_name"]["value"], "NLB DNS should not be empty"
+        assert tf_output["write_target_group_arn"]["value"]
+        assert tf_output["read_target_group_arn"]["value"]
+        assert tf_output["dynamodb_table_name"]["value"]
+        assert tf_output["s3_bucket_name"]["value"]
 
-        # Verify NLB was created
-        assert "nlb_dns_name" in tf_output, "NLB DNS name should be in outputs"
-        assert tf_output["nlb_dns_name"]["value"], "NLB DNS name should not be empty"
+        asg_name = tf_output["asg_name"]["value"]
+        nlb_dns = tf_output["nlb_dns_name"]["value"]
+        app_user = tf_output["app_user_name"]["value"]
+        app_password = tf_output["app_user_password"]["value"]
 
-        # Verify target groups were created
+        # Create ASG objects
+        percona_asg = ASG(asg_name, region=aws_region, role_arn=test_role_arn)
+        jumphost_asg_name = jumphost["jumphost_asg_name"]["value"]
+        jumphost_asg = ASG(jumphost_asg_name, region=aws_region, role_arn=test_role_arn)
+        jumphost_instance = jumphost_asg.instances[0]
+
+        LOG.info("Waiting for Puppet to finish on all Percona instances...")
+        wait_for_puppet(percona_asg)
+
+        # Find the master instance
+        master = find_master(percona_asg)
+
+        # Create application MySQL user on master
+        LOG.info("Creating application user '%s' on master...", app_user)
+        exit_code, cout, cerr = master.execute_command(
+            f'sudo mysql -u root -e "'
+            f"CREATE USER '{app_user}'@'%' IDENTIFIED BY '{app_password}';"
+            f"GRANT ALL ON sakila.* TO '{app_user}'@'%';"
+            f"FLUSH PRIVILEGES;"
+            f'"'
+        )
         assert (
-            "write_target_group_arn" in tf_output
-        ), "Write TG ARN should be in outputs"
-        assert "read_target_group_arn" in tf_output, "Read TG ARN should be in outputs"
+            exit_code == 0
+        ), f"Failed to create app user: stdout={cout}, stderr={cerr}"
 
-        # Verify DynamoDB table was created
+        # Download and load Sakila database on master
+        LOG.info("Loading Sakila database on master...")
+        exit_code, cout, cerr = master.execute_command(
+            "cd /tmp && "
+            "wget -q https://downloads.mysql.com/docs/sakila-db.tar.gz && "
+            "tar xzf sakila-db.tar.gz && "
+            "sudo mysql -u root < sakila-db/sakila-schema.sql && "
+            "sudo mysql -u root < sakila-db/sakila-data.sql",
+            execution_timeout=120,
+        )
+        assert exit_code == 0, f"Failed to load Sakila: stdout={cout}, stderr={cerr}"
+
+        # Wait for replication to catch up
+        LOG.info(
+            "Waiting %d seconds for replication to propagate...",
+            REPLICATION_WAIT,
+        )
+        time.sleep(REPLICATION_WAIT)
+
+        # Install pymysql on jumphost
+        LOG.info("Installing python3-pymysql on jumphost...")
+        exit_code, cout, cerr = jumphost_instance.execute_command(
+            "sudo apt-get install -y python3-pymysql",
+            execution_timeout=120,
+        )
         assert (
-            "dynamodb_table_name" in tf_output
-        ), "DynamoDB table name should be in outputs"
-        assert tf_output["dynamodb_table_name"][
-            "value"
-        ], "DynamoDB table name should not be empty"
+            exit_code == 0
+        ), f"Failed to install pymysql: stdout={cout}, stderr={cerr}"
 
-        # Verify S3 bucket was created
-        assert "s3_bucket_name" in tf_output, "S3 bucket name should be in outputs"
-        assert tf_output["s3_bucket_name"][
-            "value"
-        ], "S3 bucket name should not be empty"
+        # Query via NLB write endpoint (port 3306) from jumphost
+        LOG.info("Querying Sakila via NLB write endpoint...")
+        query_script = dedent(
+            f"""\
+            python3 -c "
+            import pymysql
+            conn = pymysql.connect(
+                host='{nlb_dns}',
+                port=3306,
+                user='{app_user}',
+                password='{app_password}',
+                database='sakila',
+            )
+            cur = conn.cursor()
+            cur.execute('SELECT COUNT(*) FROM actor')
+            count = cur.fetchone()[0]
+            print(f'WRITE_ACTOR_COUNT={{count}}')
+            assert count > 0, 'actor table should have rows'
+            conn.close()
+            "
+            """
+        )
+        exit_code, cout, cerr = jumphost_instance.execute_command(
+            query_script, execution_timeout=30
+        )
+        LOG.info("Write endpoint query: stdout=%s, stderr=%s", cout, cerr)
+        assert (
+            exit_code == 0
+        ), f"Write endpoint query failed: stdout={cout}, stderr={cerr}"
+        assert "WRITE_ACTOR_COUNT=" in cout
 
-        LOG.info("All infrastructure components verified successfully")
+        # Query via NLB read endpoint (port 3307) from jumphost
+        LOG.info("Querying Sakila via NLB read endpoint...")
+        query_script = dedent(
+            f"""\
+            python3 -c "
+            import pymysql
+            conn = pymysql.connect(
+                host='{nlb_dns}',
+                port=3307,
+                user='{app_user}',
+                password='{app_password}',
+                database='sakila',
+            )
+            cur = conn.cursor()
+            cur.execute('SELECT COUNT(*) FROM actor')
+            count = cur.fetchone()[0]
+            print(f'READ_ACTOR_COUNT={{count}}')
+            assert count > 0, 'actor table should have rows (replication)'
+            conn.close()
+            "
+            """
+        )
+        exit_code, cout, cerr = jumphost_instance.execute_command(
+            query_script, execution_timeout=30
+        )
+        LOG.info("Read endpoint query: stdout=%s, stderr=%s", cout, cerr)
+        assert (
+            exit_code == 0
+        ), f"Read endpoint query failed: stdout={cout}, stderr={cerr}"
+        assert "READ_ACTOR_COUNT=" in cout
+
+        LOG.info("All end-to-end verifications passed")


### PR DESCRIPTION
## Summary
                
- Add end-to-end integration test that verifies MySQL cluster functionality by loading the Sakila sample database on the master and querying it through both NLB write (3306) and read (3307) endpoints from a
jumphost
- Add app user Terraform resources (`random_password`, `random_pet`) and outputs to test data
- Rewrite `test_module.py` with jumphost fixture, Puppet wait logic, master discovery, and NLB connectivity checks

## Test plan

- [ ] `make test-keep TEST_SELECTOR=aws-6` passes end-to-end
- [ ] `make test-keep TEST_SELECTOR=aws-5` passes end-to-end
- [ ] Puppet finishes on all 3 instances within 15-minute timeout
- [ ] Master is discovered by `mysql_role` tag
- [ ] Sakila data is queryable via NLB write endpoint (port 3306)
- [ ] Sakila data is queryable via NLB read endpoint (port 3307), confirming GTID replication

Closes #3

